### PR TITLE
Add multiple calendar system support with toggle interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5152,9 +5152,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001761",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
+      "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
       "funding": [
         {
           "type": "opencollective",
@@ -5163,6 +5163,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "license": "CC-BY-4.0"

--- a/src/App.js
+++ b/src/App.js
@@ -8,18 +8,23 @@ import './App.scss';
 function App() {
   const [calendarSystem, setCalendarSystem] = useState('lunisolar');
 
+  const handleToggle = () => {
+    setCalendarSystem(calendarSystem === 'lunisolar' ? 'pagan' : 'lunisolar');
+  };
+
   return (
     <div className="App">
     <div className="calendar-selector">
-      <label htmlFor="calendar-system">Calendar System: </label>
-      <select 
-        id="calendar-system"
-        value={calendarSystem} 
-        onChange={(e) => setCalendarSystem(e.target.value)}
-      >
-        <option value="lunisolar">Lunisolar</option>
-        <option value="pagan">Pagan</option>
-      </select>
+      <span className="calendar-label">Chinese Lunisolar</span>
+      <label className="toggle-switch">
+        <input 
+          type="checkbox"
+          checked={calendarSystem === 'pagan'}
+          onChange={handleToggle}
+        />
+        <span className="slider"></span>
+      </label>
+      <span className="calendar-label">Pagan</span>
     </div>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
       <VictoryPie
@@ -35,7 +40,7 @@ function App() {
         style={{
           labels: { 
             fontFamily: "'Noto Sans TC', sans-serif",
-            fontSize: "14px",
+            fontSize: calendarSystem === 'pagan' ? "10px" : "14px",
             fill: "#6AFF19"
           },
           data: {

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ function App() {
             fill: "#6AFF19"
           },
           data: {
-            fill: ({ datum }) => dayColor( datum )
+            fill: ({ datum }) => dayColor( datum, calendarSystem )
           }
         }}
       />

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { VictoryPie, VictoryLabel } from 'victory';
 import { calendarDates } from './calendarDates.js';
 import { dayColor } from './js/dayColor.js';
@@ -6,8 +6,21 @@ import { dayColor } from './js/dayColor.js';
 import './App.scss';
 
 function App() {
+  const [calendarSystem, setCalendarSystem] = useState('lunisolar');
+
   return (
     <div className="App">
+    <div className="calendar-selector">
+      <label htmlFor="calendar-system">Calendar System: </label>
+      <select 
+        id="calendar-system"
+        value={calendarSystem} 
+        onChange={(e) => setCalendarSystem(e.target.value)}
+      >
+        <option value="lunisolar">Lunisolar</option>
+        <option value="pagan">Pagan</option>
+      </select>
+    </div>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
       <VictoryPie
         standalone={false}
@@ -15,7 +28,10 @@ function App() {
         data={calendarDates}
         innerRadius={120}
         labelRadius={160}
-        labels={() => null}
+        labels={({ datum }) => {
+          const labelValue = datum.calendarLabels[calendarSystem];
+          return labelValue ? String(labelValue) : '';
+        }}
         style={{
           labels: { 
             fontFamily: "'Noto Sans TC', sans-serif",

--- a/src/App.js
+++ b/src/App.js
@@ -2,29 +2,37 @@ import React, { useState } from 'react';
 import { VictoryPie, VictoryLabel } from 'victory';
 import { calendarDates } from './calendarDates.js';
 import { dayColor } from './js/dayColor.js';
+import { CALENDAR_SYSTEMS, CALENDAR_CONFIG } from './constants/calendarSystems.js';
+import { getCalendarLabel } from './utils/calendarUtils.js';
 
 import './App.scss';
 
 function App() {
-  const [calendarSystem, setCalendarSystem] = useState('lunisolar');
+  const [calendarSystem, setCalendarSystem] = useState(CALENDAR_SYSTEMS.LUNISOLAR);
 
   const handleToggle = () => {
-    setCalendarSystem(calendarSystem === 'lunisolar' ? 'pagan' : 'lunisolar');
+    setCalendarSystem(
+      calendarSystem === CALENDAR_SYSTEMS.LUNISOLAR 
+        ? CALENDAR_SYSTEMS.PAGAN 
+        : CALENDAR_SYSTEMS.LUNISOLAR
+    );
   };
+
+  const currentConfig = CALENDAR_CONFIG[calendarSystem];
 
   return (
     <div className="App">
     <div className="calendar-selector">
-      <span className="calendar-label">Chinese Lunisolar</span>
+      <span className="calendar-label">{CALENDAR_CONFIG[CALENDAR_SYSTEMS.LUNISOLAR].displayName}</span>
       <label className="toggle-switch">
         <input 
           type="checkbox"
-          checked={calendarSystem === 'pagan'}
+          checked={calendarSystem === CALENDAR_SYSTEMS.PAGAN}
           onChange={handleToggle}
         />
         <span className="slider"></span>
       </label>
-      <span className="calendar-label">Pagan</span>
+      <span className="calendar-label">{CALENDAR_CONFIG[CALENDAR_SYSTEMS.PAGAN].displayName}</span>
     </div>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
       <VictoryPie
@@ -33,14 +41,11 @@ function App() {
         data={calendarDates}
         innerRadius={120}
         labelRadius={160}
-        labels={({ datum }) => {
-          const labelValue = datum.calendarLabels[calendarSystem];
-          return labelValue ? String(labelValue) : '';
-        }}
+        labels={({ datum }) => getCalendarLabel(datum, calendarSystem)}
         style={{
           labels: { 
             fontFamily: "'Noto Sans TC', sans-serif",
-            fontSize: calendarSystem === 'pagan' ? "10px" : "14px",
+            fontSize: currentConfig.labelFontSize,
             fill: "#6AFF19"
           },
           data: {

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,30 +13,63 @@ svg {
   padding: 20px;
   background-color: #f0f0f0;
   margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
   
-  label {
-    margin-right: 10px;
+  .calendar-label {
     font-weight: bold;
     color: #379E00;
+    font-size: 16px;
   }
   
-  select {
-    padding: 8px 12px;
-    font-size: 16px;
-    border: 2px solid #379E00;
-    border-radius: 4px;
-    background-color: white;
-    cursor: pointer;
-    font-family: 'Noto Sans TC', sans-serif;
+  .toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
     
-    &:hover {
-      border-color: #52EB00;
+    input {
+      opacity: 0;
+      width: 0;
+      height: 0;
     }
     
-    &:focus {
-      outline: none;
-      border-color: #6AFF19;
-      box-shadow: 0 0 5px rgba(106, 255, 25, 0.5);
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #379E00;
+      transition: .4s;
+      border-radius: 34px;
+      
+      &:before {
+        position: absolute;
+        content: "";
+        height: 26px;
+        width: 26px;
+        left: 4px;
+        bottom: 4px;
+        background-color: white;
+        transition: .4s;
+        border-radius: 50%;
+      }
+    }
+    
+    input:checked + .slider {
+      background-color: #9E009E;
+    }
+    
+    input:focus + .slider {
+      box-shadow: 0 0 1px #9E009E;
+    }
+    
+    input:checked + .slider:before {
+      transform: translateX(26px);
     }
   }
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -9,6 +9,38 @@ svg {
   text-align: center;
 }
 
+.calendar-selector {
+  padding: 20px;
+  background-color: #f0f0f0;
+  margin-bottom: 10px;
+  
+  label {
+    margin-right: 10px;
+    font-weight: bold;
+    color: #379E00;
+  }
+  
+  select {
+    padding: 8px 12px;
+    font-size: 16px;
+    border: 2px solid #379E00;
+    border-radius: 4px;
+    background-color: white;
+    cursor: pointer;
+    font-family: 'Noto Sans TC', sans-serif;
+    
+    &:hover {
+      border-color: #52EB00;
+    }
+    
+    &:focus {
+      outline: none;
+      border-color: #6AFF19;
+      box-shadow: 0 0 5px rgba(106, 255, 25, 0.5);
+    }
+  }
+}
+
 .App-link {
   color: #61dafb;
 }

--- a/src/calendarDates.js
+++ b/src/calendarDates.js
@@ -3,2555 +3,2555 @@ export const calendarDates = [
     "x": "June 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": "夏至",
+    "label": { "lunisolar": "夏至" },
     "sandex": 3
   },
   {
     "x": "June 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "June 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "June 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "June 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "June 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 7",
     "y": 1,
     "fill": "#52EB00",
-    "label": "小暑",
+    "label": { "lunisolar": "小暑" },
     "sandex": 1
   },
   {
     "x": "July 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "July 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "July 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "July 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": "大暑",
+    "label": { "lunisolar": "大暑" },
     "sandex": 1
   },
   {
     "x": "July 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "July 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "July 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "July 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "July 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "July 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "August 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 8",
     "y": 1,
     "fill": "#6AFF19",
-    "label": "立秋",
+    "label": { "lunisolar": "立秋" },
     "sandex": 3
   },
   {
     "x": "August 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "August 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "August 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "August 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": "處暑",
+    "label": { "lunisolar": "處暑" },
     "sandex": 4
   },
   {
     "x": "August 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "August 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "August 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "August 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "August 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "August 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "August 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "September 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "September 8",
     "y": 1,
     "fill": "#52EB00",
-    "label": "白露",
+    "label": { "lunisolar": "白露" },
     "sandex": 3
   },
   {
     "x": "September 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "September 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "September 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "September 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": "秋分",
+    "label": { "lunisolar": "秋分" },
     "sandex": 5
   },
   {
     "x": "September 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "September 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "September 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "September 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "September 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "October 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "October 8",
     "y": 1,
     "fill": "#52EB00",
-    "label": "寒露",
+    "label": { "lunisolar": "寒露" },
     "sandex": 2
   },
   {
     "x": "October 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "October 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": "霜降",
+    "label": { "lunisolar": "霜降" },
     "sandex": 0
   },
   {
     "x": "October 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "October 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "October 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "October 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 7",
     "y": 1,
     "fill": "#6AFF19",
-    "label": "立冬",
+    "label": { "lunisolar": "立冬" },
     "sandex": 1
   },
   {
     "x": "November 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "November 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 22",
     "y": 1,
     "fill": "#52EB00",
-    "label": "小雪",
+    "label": { "lunisolar": "小雪" },
     "sandex": 0
   },
   {
     "x": "November 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "November 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 7",
     "y": 1,
     "fill": "#52EB00",
-    "label": "大雪",
+    "label": { "lunisolar": "大雪" },
     "sandex": 0
   },
   {
     "x": "December 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "December 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 22",
     "y": 1,
     "fill": "#52EB00",
-    "label": "冬至",
+    "label": { "lunisolar": "冬至" },
     "sandex": 0
   },
   {
     "x": "December 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "December 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": "小寒",
+    "label": { "lunisolar": "小寒" },
     "sandex": 0
   },
   {
     "x": "January 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 20",
     "y": 1,
     "fill": "#52EB00",
-    "label": "大寒",
+    "label": { "lunisolar": "大寒" },
     "sandex": 0
   },
   {
     "x": "January 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "January 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 4",
     "y": 1,
     "fill": "#6AFF19",
-    "label": "立春",
+    "label": { "lunisolar": "立春" },
     "sandex": 0
   },
   {
     "x": "February 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 19",
     "y": 1,
     "fill": "#52EB00",
-    "label": "雨水",
+    "label": { "lunisolar": "雨水" },
     "sandex": 1
   },
   {
     "x": "February 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "February 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "February 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "February 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "February 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": "驚蟄",
+    "label": { "lunisolar": "驚蟄" },
     "sandex": 0
   },
   {
     "x": "March 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": "春分",
+    "label": { "lunisolar": "春分" },
     "sandex": 1
   },
   {
     "x": "March 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "March 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "March 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "March 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "April 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "April 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 5",
     "y": 1,
     "fill": "#52EB00",
-    "label": "清明",
+    "label": { "lunisolar": "清明" },
     "sandex": 0
   },
   {
     "x": "April 6",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "April 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "April 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "April 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "April 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "April 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "April 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "April 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 20",
     "y": 1,
     "fill": "#52EB00",
-    "label": "穀雨",
+    "label": { "lunisolar": "穀雨" },
     "sandex": 2
   },
   {
     "x": "April 21",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "April 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "April 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "April 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "April 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "April 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "April 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "May 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 6",
     "y": 1,
     "fill": "#6AFF19",
-    "label": "立夏",
+    "label": { "lunisolar": "立夏" },
     "sandex": 2
   },
   {
     "x": "May 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "May 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "May 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "May 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "May 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": "小滿",
+    "label": { "lunisolar": "小滿" },
     "sandex": 3
   },
   {
     "x": "May 22",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 23",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "May 24",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 6
   },
   {
     "x": "May 25",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "May 26",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 27",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "May 28",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 0
   },
   {
     "x": "May 29",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "May 30",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "May 31",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "June 1",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "June 2",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "June 3",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 4",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "June 5",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "June 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": "芒種",
+    "label": { "lunisolar": "芒種" },
     "sandex": 4
   },
   {
     "x": "June 7",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 6
   },
   {
     "x": "June 8",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 6
   },
   {
     "x": "June 9",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "June 10",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 5
   },
   {
     "x": "June 11",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "June 12",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 13",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 2
   },
   {
     "x": "June 14",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 6
   },
   {
     "x": "June 15",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 6
   },
   {
     "x": "June 16",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 3
   },
   {
     "x": "June 17",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   },
   {
     "x": "June 18",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "June 19",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 1
   },
   {
     "x": "June 20",
     "y": 1,
     "fill": "",
-    "label": "",
+    "label": {},
     "sandex": 4
   }
 ]

--- a/src/calendarDates.js
+++ b/src/calendarDates.js
@@ -3,2555 +3,2555 @@ export const calendarDates = [
     "x": "June 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "夏至" },
+    "calendarLabels": { "lunisolar": "夏至" },
     "sandex": 3
   },
   {
     "x": "June 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "June 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "June 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "June 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "June 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 7",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "小暑" },
+    "calendarLabels": { "lunisolar": "小暑" },
     "sandex": 1
   },
   {
     "x": "July 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "July 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "July 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "July 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "大暑" },
+    "calendarLabels": { "lunisolar": "大暑" },
     "sandex": 1
   },
   {
     "x": "July 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "July 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "July 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "July 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "July 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "July 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "August 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 8",
     "y": 1,
     "fill": "#6AFF19",
-    "label": { "lunisolar": "立秋" },
+    "calendarLabels": { "lunisolar": "立秋" },
     "sandex": 3
   },
   {
     "x": "August 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "August 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "August 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "August 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "處暑" },
+    "calendarLabels": { "lunisolar": "處暑" },
     "sandex": 4
   },
   {
     "x": "August 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "August 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "August 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "August 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "August 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "August 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "August 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "September 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "September 8",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "白露" },
+    "calendarLabels": { "lunisolar": "白露" },
     "sandex": 3
   },
   {
     "x": "September 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "September 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "September 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "September 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "秋分" },
+    "calendarLabels": { "lunisolar": "秋分" },
     "sandex": 5
   },
   {
     "x": "September 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "September 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "September 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "September 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "September 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "October 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "October 8",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "寒露" },
+    "calendarLabels": { "lunisolar": "寒露" },
     "sandex": 2
   },
   {
     "x": "October 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "October 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 23",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "霜降" },
+    "calendarLabels": { "lunisolar": "霜降" },
     "sandex": 0
   },
   {
     "x": "October 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "October 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "October 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "October 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 7",
     "y": 1,
     "fill": "#6AFF19",
-    "label": { "lunisolar": "立冬" },
+    "calendarLabels": { "lunisolar": "立冬" },
     "sandex": 1
   },
   {
     "x": "November 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "November 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 22",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "小雪" },
+    "calendarLabels": { "lunisolar": "小雪" },
     "sandex": 0
   },
   {
     "x": "November 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "November 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 7",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "大雪" },
+    "calendarLabels": { "lunisolar": "大雪" },
     "sandex": 0
   },
   {
     "x": "December 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "December 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 22",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "冬至" },
+    "calendarLabels": { "lunisolar": "冬至" },
     "sandex": 0
   },
   {
     "x": "December 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {"pagan": "Yule"},
     "sandex": 0
   },
   {
     "x": "December 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "December 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "小寒" },
+    "calendarLabels": { "lunisolar": "小寒" },
     "sandex": 0
   },
   {
     "x": "January 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 20",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "大寒" },
+    "calendarLabels": { "lunisolar": "大寒" },
     "sandex": 0
   },
   {
     "x": "January 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "January 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 4",
     "y": 1,
     "fill": "#6AFF19",
-    "label": { "lunisolar": "立春" },
+    "calendarLabels": { "lunisolar": "立春" },
     "sandex": 0
   },
   {
     "x": "February 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 19",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "雨水" },
+    "calendarLabels": { "lunisolar": "雨水" },
     "sandex": 1
   },
   {
     "x": "February 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "February 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "February 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "February 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "February 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "驚蟄" },
+    "calendarLabels": { "lunisolar": "驚蟄" },
     "sandex": 0
   },
   {
     "x": "March 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "春分" },
+    "calendarLabels": { "lunisolar": "春分" },
     "sandex": 1
   },
   {
     "x": "March 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "March 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "March 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "March 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "April 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "April 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 5",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "清明" },
+    "calendarLabels": { "lunisolar": "清明" },
     "sandex": 0
   },
   {
     "x": "April 6",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "April 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "April 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "April 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "April 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "April 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "April 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "April 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 20",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "穀雨" },
+    "calendarLabels": { "lunisolar": "穀雨" },
     "sandex": 2
   },
   {
     "x": "April 21",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "April 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "April 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "April 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "April 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "April 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "April 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "May 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 6",
     "y": 1,
     "fill": "#6AFF19",
-    "label": { "lunisolar": "立夏" },
+    "calendarLabels": { "lunisolar": "立夏" },
     "sandex": 2
   },
   {
     "x": "May 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "May 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "May 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "May 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "May 21",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "小滿" },
+    "calendarLabels": { "lunisolar": "小滿" },
     "sandex": 3
   },
   {
     "x": "May 22",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 23",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "May 24",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 6
   },
   {
     "x": "May 25",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "May 26",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 27",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "May 28",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
     "x": "May 29",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "May 30",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "May 31",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "June 1",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "June 2",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "June 3",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 4",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "June 5",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "June 6",
     "y": 1,
     "fill": "#52EB00",
-    "label": { "lunisolar": "芒種" },
+    "calendarLabels": { "lunisolar": "芒種" },
     "sandex": 4
   },
   {
     "x": "June 7",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 6
   },
   {
     "x": "June 8",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 6
   },
   {
     "x": "June 9",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "June 10",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 5
   },
   {
     "x": "June 11",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "June 12",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 13",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 2
   },
   {
     "x": "June 14",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 6
   },
   {
     "x": "June 15",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 6
   },
   {
     "x": "June 16",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 3
   },
   {
     "x": "June 17",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   },
   {
     "x": "June 18",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "June 19",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 1
   },
   {
     "x": "June 20",
     "y": 1,
     "fill": "",
-    "label": {},
+    "calendarLabels": {},
     "sandex": 4
   }
 ]

--- a/src/calendarDates.js
+++ b/src/calendarDates.js
@@ -3,7 +3,7 @@ export const calendarDates = [
     "x": "June 21",
     "y": 1,
     "fill": "#52EB00",
-    "calendarLabels": { "lunisolar": "夏至" },
+    "calendarLabels": { "lunisolar": "夏至", "pagan": "Litha" },
     "sandex": 3
   },
   {
@@ -290,7 +290,7 @@ export const calendarDates = [
     "x": "August 1",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Lughnasadh" },
     "sandex": 1
   },
   {
@@ -654,7 +654,7 @@ export const calendarDates = [
     "x": "September 22",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Mabon" },
     "sandex": 5
   },
   {
@@ -927,7 +927,7 @@ export const calendarDates = [
     "x": "October 31",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Samhain" },
     "sandex": 1
   },
   {
@@ -1284,7 +1284,7 @@ export const calendarDates = [
     "x": "December 21",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": {"pagan": "Yule"},
     "sandex": 0
   },
   {
@@ -1312,7 +1312,7 @@ export const calendarDates = [
     "x": "December 25",
     "y": 1,
     "fill": "",
-    "calendarLabels": {"pagan": "Yule"},
+    "calendarLabels": {},
     "sandex": 0
   },
   {
@@ -1578,7 +1578,7 @@ export const calendarDates = [
     "x": "February 1",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Imbolc" },
     "sandex": 0
   },
   {
@@ -1907,7 +1907,7 @@ export const calendarDates = [
     "x": "March 20",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Ostara" },
     "sandex": 0
   },
   {
@@ -2201,7 +2201,7 @@ export const calendarDates = [
     "x": "May 1",
     "y": 1,
     "fill": "",
-    "calendarLabels": {},
+    "calendarLabels": { "pagan": "Beltane" },
     "sandex": 2
   },
   {

--- a/src/constants/calendarSystems.js
+++ b/src/constants/calendarSystems.js
@@ -1,0 +1,15 @@
+export const CALENDAR_SYSTEMS = {
+  LUNISOLAR: 'lunisolar',
+  PAGAN: 'pagan'
+};
+
+export const CALENDAR_CONFIG = {
+  [CALENDAR_SYSTEMS.LUNISOLAR]: {
+    displayName: 'Chinese Lunisolar',
+    labelFontSize: '14px'
+  },
+  [CALENDAR_SYSTEMS.PAGAN]: {
+    displayName: 'Pagan',
+    labelFontSize: '10px'
+  }
+};

--- a/src/js/dayColor.js
+++ b/src/js/dayColor.js
@@ -8,7 +8,9 @@ export const dayColor = (datum) => {
     const currentDay = today.getDate();
     const dayToMatch = `${currentMonthName} ${currentDay}`;
     if ( datum.x === dayToMatch ) { return "#EA00EB" }
-    if ( datum.label.toString().length > 0 ) { return "#9E009E" }
+    
+    // Check if label object has any calendar system defined
+    if ( datum.label && Object.keys(datum.label).length > 0 ) { return "#9E009E" }
 
     const colors = "#003300 #004400 #005500 #006600 #009900 #00CC00 #00FF00".split(' ');
     return colors[datum.sandex];

--- a/src/js/dayColor.js
+++ b/src/js/dayColor.js
@@ -1,4 +1,4 @@
-export const dayColor = (datum) => {
+export const dayColor = (datum, calendarSystem) => {
 
     // if the date is today, return #EA00EB
     const today = new Date();
@@ -9,8 +9,8 @@ export const dayColor = (datum) => {
     const dayToMatch = `${currentMonthName} ${currentDay}`;
     if ( datum.x === dayToMatch ) { return "#EA00EB" }
     
-    // Check if label object has any calendar system defined
-    if ( datum.calendarLabels && Object.keys(datum.calendarLabels).length > 0 ) { return "#9E009E" }
+    // Check if label exists for the currently active calendar system
+    if ( datum.calendarLabels && datum.calendarLabels[calendarSystem] ) { return "#9E009E" }
 
     const colors = "#003300 #004400 #005500 #006600 #009900 #00CC00 #00FF00".split(' ');
     return colors[datum.sandex];

--- a/src/js/dayColor.js
+++ b/src/js/dayColor.js
@@ -10,7 +10,7 @@ export const dayColor = (datum) => {
     if ( datum.x === dayToMatch ) { return "#EA00EB" }
     
     // Check if label object has any calendar system defined
-    if ( datum.label && Object.keys(datum.label).length > 0 ) { return "#9E009E" }
+    if ( datum.calendarLabels && Object.keys(datum.calendarLabels).length > 0 ) { return "#9E009E" }
 
     const colors = "#003300 #004400 #005500 #006600 #009900 #00CC00 #00FF00".split(' ');
     return colors[datum.sandex];

--- a/src/js/dayColor.js
+++ b/src/js/dayColor.js
@@ -1,3 +1,5 @@
+import { hasCalendarLabel } from '../utils/calendarUtils.js';
+
 export const dayColor = (datum, calendarSystem) => {
 
     // if the date is today, return #EA00EB
@@ -10,7 +12,7 @@ export const dayColor = (datum, calendarSystem) => {
     if ( datum.x === dayToMatch ) { return "#EA00EB" }
     
     // Check if label exists for the currently active calendar system
-    if ( datum.calendarLabels && datum.calendarLabels[calendarSystem] ) { return "#9E009E" }
+    if ( hasCalendarLabel(datum, calendarSystem) ) { return "#9E009E" }
 
     const colors = "#003300 #004400 #005500 #006600 #009900 #00CC00 #00FF00".split(' ');
     return colors[datum.sandex];

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -1,0 +1,8 @@
+export const getCalendarLabel = (datum, calendarSystem) => {
+  const labelValue = datum.calendarLabels?.[calendarSystem];
+  return labelValue ? String(labelValue) : '';
+};
+
+export const hasCalendarLabel = (datum, calendarSystem) => {
+  return Boolean(datum.calendarLabels?.[calendarSystem]);
+};

--- a/transform-label-property.js
+++ b/transform-label-property.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const content = fs.readFileSync('src/calendarDates.js', 'utf8');
+
+// Replace "label": with "calendarLabels":
+let updated = content.replace(/"label":/g, '"calendarLabels":');
+
+fs.writeFileSync('src/calendarDates.js', updated, 'utf8');
+console.log('Successfully renamed label to calendarLabels in calendarDates.js');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,6 +1394,11 @@
   resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz"
   integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
 
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
 "@parcel/watcher@^2.4.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz"
@@ -2836,9 +2841,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317:
-  version "1.0.30001332"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz"
-  integrity sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==
+  version "1.0.30001761"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz"
+  integrity sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## Overview
This PR adds support for multiple calendar systems, allowing users to toggle between Chinese Lunisolar and Pagan calendar labels on the Wheel of the Year visualization.

## Changes Made

### 1. Data Structure Refactoring
- Changed `label` property to `calendarLabels` object structure in `calendarDates.js`
- Supports multiple calendar systems: `{ "lunisolar": "夏至", "pagan": "Litha" }`

### 2. Calendar Systems Added
- **Chinese Lunisolar**: All 24 solar terms (existing)
- **Pagan Wheel of the Year**: All 8 sabbats added:
  - Yule (December 21)
  - Imbolc (February 1)
  - Ostara (March 20)
  - Beltane (May 1)
  - Litha (June 21)
  - Lughnasadh (August 1)
  - Mabon (September 22)
  - Samhain (October 31)

### 3. User Interface
- Replaced dropdown with toggle switch for better UX
- Toggle between Chinese Lunisolar (left) and Pagan (right)
- Color-coded toggle: green for Lunisolar, purple for Pagan
- Responsive font sizing: 14px for Chinese labels, 10px for longer English labels

### 4. Color System Enhancement
- Updated `dayColor.js` to highlight dates only when they have labels in the **currently selected** calendar system
- Purple highlights (#9E009E) now context-aware

### 5. Code Quality Improvements
- Created `constants/calendarSystems.js` for system configuration
- Created `utils/calendarUtils.js` for reusable helper functions
- Eliminated magic strings and hardcoded values
- Centralized calendar system configuration

## Technical Details
- All tests passing ✅
- Build successful ✅
- No breaking changes to existing functionality
- Backward compatible data structure (empty objects for dates without labels)

## Files Changed
- `src/calendarDates.js` - Updated data structure for all 365 days
- `src/App.js` - Added toggle UI and calendar system state management
- `src/App.scss` - Styled toggle switch component
- `src/js/dayColor.js` - Updated to use calendar system parameter
- `src/constants/calendarSystems.js` - NEW: Calendar system constants and config
- `src/utils/calendarUtils.js` - NEW: Label utility functions

## Future Extensibility
The new architecture makes it easy to add additional calendar systems (e.g., Hebrew, Islamic, etc.) by simply:
1. Adding configuration to `CALENDAR_CONFIG`
2. Adding labels to `calendarDates.js`
3. Updating the UI toggle (if needed for 3+ systems)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added toggle to switch between Chinese Lunisolar and Pagan calendar systems
  * Calendar labels and styling now dynamically update based on the selected system
  * Chart appearance adapts to the active calendar selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->