### PR TITLE
Add wrangler.jsonc for Cloudflare Workers static asset deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "wheel-of-the-year",
+  "compatibility_date": "2026-04-08",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
Provides config so `wrangler deploy` knows to serve the Vite build output as static assets (SPA mode) without running auto-setup that injects @cloudflare/vite-plugin.

https://claude.ai/code/session_01HsGPuoJd3uPtEFDTq8yY5h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Configured project deployment settings and single-page application routing to enable proper asset serving and client-side navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->